### PR TITLE
Update logrus prefixed formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ _testmain.go
 
 # OS X
 .DS_Store
+
+# Unit testing
+*.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+  - 1.5
+  - 1.6
+  - 1.7
+
+install:
+  - make deps
+
+script:
+  - make test
+
+sudo: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Denis Parchenko
+Copyright (c) 2017 Denis Parchenko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+NAME=logrus-prefixed-formatter
+PACKAGES=$(shell go list ./...)
+
+deps:
+	@echo "--> Installing dependencies"
+	@go get -d -v -t ./...
+
+test-deps:
+	@which ginkgo 2>/dev/null ; if [ $$? -eq 1 ]; then \
+		go get -u -v github.com/onsi/ginkgo/ginkgo; \
+	fi
+
+test: test-deps
+	@echo "--> Running tests"
+	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover --trace --race
+
+format:
+	@echo "--> Running go fmt"
+	@go fmt $(PACKAGES)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Logrus Prefixed Log Formatter
 [Logrus](https://github.com/Sirupsen/logrus) formatter mainly based on original `logrus.TextFormatter` but with slightly
-modified colored output and support for log entry prefixes, e.g. message source followed by a colon.
+modified colored output and support for log entry prefixes, e.g. message source followed by a colon. In addition, custom
+color themes are supported.
 
 ![Formatter screenshot](http://cl.ly/image/1w0B3F233F3z/formatter-screenshot@2x.png)
 
@@ -62,10 +63,12 @@ func main() {
 * `ForceColors bool` — set to true to bypass checking for a TTY before outputting colors.
 * `DisableColors bool` — force disabling colors.
 * `DisableTimestamp bool` — disable timestamp logging. useful when output is redirected to logging system that already adds timestamps.
-* `ShortTimestamp bool` — enable logging of just the time passed since beginning of execution.
+* `FullTimestamp bool` — enable logging the full timestamp when a TTY is attached instead of just the time passed since beginning of execution.
 * `TimestampFormat string` — timestamp format to use for display when a full timestamp is printed.
 * `DisableSorting bool` — the fields are sorted by default for a consistent output. For applications that log extremely frequently and don't use the JSON formatter this may not be desired.
-* `SpacePadding int` — Pad msg field with spaces on the right for display. The value for this parameter will be the size of padding. Its default value is zero, which means no padding will be applied.
+* `QuoteEmptyFields bool` - wrap empty fields in quotes if true.
+* `QuoteCharacter string` - can be set to the override the default quoting character `"` with something else. For example: `'`, or `` ` ``.
+* `SpacePadding int` — pad msg field with spaces on the right for display. The value for this parameter will be the size of padding. Its default value is zero, which means no padding will be applied.
 
 # License
 MIT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Logrus Prefixed Log Formatter
-[![Build Status](https://travis-ci.org/x-cray/logrus-prefixed-formatter.svg?branch=master)](https://travis-ci.org/x-cray/logrus-prefixed-formatter.svg)
+[![Build Status](https://travis-ci.org/x-cray/logrus-prefixed-formatter.svg?branch=master)](https://travis-ci.org/x-cray/logrus-prefixed-formatter)
 
 [Logrus](https://github.com/Sirupsen/logrus) formatter mainly based on original `logrus.TextFormatter` but with slightly
 modified colored output and support for log entry prefixes, e.g. message source followed by a colon. In addition, custom

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ func main() {
 ### Fields
 
 * `ForceColors bool` — set to true to bypass checking for a TTY before outputting colors.
-* `DisableColors bool` — force disabling colors.
+* `DisableColors bool` — force disabling colors. For a TTY colors are enabled by default.
+* `ForceFormatting bool` — force formatted layout, even for non-TTY output.
 * `DisableTimestamp bool` — disable timestamp logging. Useful when output is redirected to logging system that already adds timestamps.
 * `FullTimestamp bool` — enable logging the full timestamp when a TTY is attached instead of just the time passed since beginning of execution.
 * `TimestampFormat string` — timestamp format to use for display when a full timestamp is printed.
@@ -74,9 +75,9 @@ func main() {
 
 ### Methods
 
-#### `SetColorScheme(colorScheme *ColorScheme)`
+#### `SetColorScheme(colorScheme *prefixed.ColorScheme)`
 
-Sets an alternative color scheme for colored output. `ColorScheme` struct supports the following fields:
+Sets an alternative color scheme for colored output. `prefixed.ColorScheme` struct supports the following fields:
 * `InfoLevelStyle string` — info level style.
 * `WarnLevelStyle string` — warn level style.
 * `ErrorLevelStyle string` — error style.

--- a/README.md
+++ b/README.md
@@ -90,14 +90,23 @@ Sets an alternative color scheme for colored output. `prefixed.ColorScheme` stru
 Color styles should be specified using [mgutz/ansi](https://github.com/mgutz/ansi#style-format) style syntax. For example, here is the default theme:
 
 ```go
-InfoLevelStyle: "green",
-WarnLevelStyle: "yellow",
+InfoLevelStyle:  "green",
+WarnLevelStyle:  "yellow",
 ErrorLevelStyle: "red",
 FatalLevelStyle: "red",
 PanicLevelStyle: "red",
 DebugLevelStyle: "blue",
-PrefixStyle: "cyan",
-TimestampStyle: "black+h"
+PrefixStyle:     "cyan",
+TimestampStyle:  "black+h"
+```
+
+It's not necessary to specify all colors when changing color scheme if you want to change just specific ones:
+
+```go
+formatter.SetColorScheme(&prefixed.ColorScheme{
+    PrefixStyle:    "blue+b",
+    TimestampStyle: "white+h",
+})
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Logrus Prefixed Log Formatter
+[![Build Status](https://travis-ci.org/x-cray/logrus-prefixed-formatter.svg?branch=master)](https://travis-ci.org/x-cray/logrus-prefixed-formatter.svg)
+
 [Logrus](https://github.com/Sirupsen/logrus) formatter mainly based on original `logrus.TextFormatter` but with slightly
 modified colored output and support for log entry prefixes, e.g. message source followed by a colon. In addition, custom
 color themes are supported.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Logrus Prefixed Log Formatter
 [![Build Status](https://travis-ci.org/x-cray/logrus-prefixed-formatter.svg?branch=master)](https://travis-ci.org/x-cray/logrus-prefixed-formatter)
 
-[Logrus](https://github.com/Sirupsen/logrus) formatter mainly based on original `logrus.TextFormatter` but with slightly
+[Logrus](https://github.com/sirupsen/logrus) formatter mainly based on original `logrus.TextFormatter` but with slightly
 modified colored output and support for log entry prefixes, e.g. message source followed by a colon. In addition, custom
 color themes are supported.
 
@@ -34,7 +34,7 @@ Here is how it should be used:
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ func main() {
 
 * `ForceColors bool` — set to true to bypass checking for a TTY before outputting colors.
 * `DisableColors bool` — force disabling colors. For a TTY colors are enabled by default.
+* `DisableUppercase bool` — set to true to turn off the conversion of the log level names to uppercase.
 * `ForceFormatting bool` — force formatted layout, even for non-TTY output.
 * `DisableTimestamp bool` — disable timestamp logging. Useful when output is redirected to logging system that already adds timestamps.
 * `FullTimestamp bool` — enable logging the full timestamp when a TTY is attached instead of just the time passed since beginning of execution.

--- a/README.md
+++ b/README.md
@@ -58,17 +58,46 @@ func main() {
 ```
 
 ## API
-`prefixed.TextFormatter` exposes the following fields:
+`prefixed.TextFormatter` exposes the following fields and methods.
+
+### Fields
 
 * `ForceColors bool` — set to true to bypass checking for a TTY before outputting colors.
 * `DisableColors bool` — force disabling colors.
-* `DisableTimestamp bool` — disable timestamp logging. useful when output is redirected to logging system that already adds timestamps.
+* `DisableTimestamp bool` — disable timestamp logging. Useful when output is redirected to logging system that already adds timestamps.
 * `FullTimestamp bool` — enable logging the full timestamp when a TTY is attached instead of just the time passed since beginning of execution.
 * `TimestampFormat string` — timestamp format to use for display when a full timestamp is printed.
 * `DisableSorting bool` — the fields are sorted by default for a consistent output. For applications that log extremely frequently and don't use the JSON formatter this may not be desired.
-* `QuoteEmptyFields bool` - wrap empty fields in quotes if true.
-* `QuoteCharacter string` - can be set to the override the default quoting character `"` with something else. For example: `'`, or `` ` ``.
+* `QuoteEmptyFields bool` — wrap empty fields in quotes if true.
+* `QuoteCharacter string` — can be set to the override the default quoting character `"` with something else. For example: `'`, or `` ` ``.
 * `SpacePadding int` — pad msg field with spaces on the right for display. The value for this parameter will be the size of padding. Its default value is zero, which means no padding will be applied.
+
+### Methods
+
+#### `SetColorScheme(colorScheme *ColorScheme)`
+
+Sets an alternative color scheme for colored output. `ColorScheme` struct supports the following fields:
+* `InfoLevelStyle string` — info level style.
+* `WarnLevelStyle string` — warn level style.
+* `ErrorLevelStyle string` — error style.
+* `FatalLevelStyle string` — fatal level style.
+* `PanicLevelStyle string` — panic level style.
+* `DebugLevelStyle string` — debug level style.
+* `PrefixStyle string` — prefix style.
+* `TimestampStyle string` — timestamp style.
+
+Color styles should be specified using [mgutz/ansi](https://github.com/mgutz/ansi#style-format) style syntax. For example, here is the default theme:
+
+```go
+InfoLevelStyle: "green",
+WarnLevelStyle: "yellow",
+ErrorLevelStyle: "red",
+FatalLevelStyle: "red",
+PanicLevelStyle: "red",
+DebugLevelStyle: "blue",
+PrefixStyle: "cyan",
+TimestampStyle: "black+h"
+```
 
 # License
 MIT

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -9,10 +9,13 @@ var log = logrus.New()
 
 func init() {
 	formatter := new(prefixed.TextFormatter)
+
+	// Set specific colors for prefix and timestamp
 	formatter.SetColorScheme(&prefixed.ColorScheme{
 		PrefixStyle:    "blue+b",
 		TimestampStyle: "white+h",
 	})
+
 	log.Formatter = formatter
 	log.Level = logrus.DebugLevel
 }

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -8,7 +8,12 @@ import (
 var log = logrus.New()
 
 func init() {
-	log.Formatter = new(prefixed.TextFormatter)
+	formatter := new(prefixed.TextFormatter)
+	formatter.SetColorScheme(&prefixed.ColorScheme{
+		PrefixStyle: "blue+b",
+		TimestampStyle: "white+h",
+	})
+	log.Formatter = formatter
 	log.Level = logrus.DebugLevel
 }
 

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -10,7 +10,7 @@ var log = logrus.New()
 func init() {
 	formatter := new(prefixed.TextFormatter)
 	formatter.SetColorScheme(&prefixed.ColorScheme{
-		PrefixStyle: "blue+b",
+		PrefixStyle:    "blue+b",
 		TimestampStyle: "white+h",
 	})
 	log.Formatter = formatter

--- a/examples/themes.go
+++ b/examples/themes.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 

--- a/examples/themes.go
+++ b/examples/themes.go
@@ -9,23 +9,19 @@ var log = logrus.New()
 
 func init() {
 	formatter := new(prefixed.TextFormatter)
+	formatter.FullTimestamp = true
+
+	// Set specific colors for prefix and timestamp
+	formatter.SetColorScheme(&prefixed.ColorScheme{
+		PrefixStyle:    "blue+b",
+		TimestampStyle: "white+h",
+	})
+
 	log.Formatter = formatter
 	log.Level = logrus.DebugLevel
 }
 
 func main() {
-	defer func() {
-		err := recover()
-		if err != nil {
-			// Fatal message
-			log.WithFields(logrus.Fields{
-				"omg":    true,
-				"number": 100,
-			}).Fatal("[main] The ice breaks!")
-		}
-	}()
-
-	// You could either provide a map key called `prefix` to add prefix
 	log.WithFields(logrus.Fields{
 		"prefix": "main",
 		"animal": "walrus",
@@ -49,11 +45,4 @@ func main() {
 		"prefix":      "sensor",
 		"temperature": -4,
 	}).Info("Temperature changes")
-
-	// Panic message
-	log.WithFields(logrus.Fields{
-		"prefix": "sensor",
-		"animal": "orca",
-		"size":   9009,
-	}).Panic("It's over 9000!")
 }

--- a/formatter.go
+++ b/formatter.go
@@ -78,6 +78,9 @@ type TextFormatter struct {
 	// system that already adds timestamps.
 	DisableTimestamp bool
 
+	// Disable the conversion of the log levels to uppercase
+	DisableUppercase bool
+
 	// Enable logging the full timestamp when a TTY is attached instead of just
 	// the time passed since beginning of execution.
 	FullTimestamp bool
@@ -222,9 +225,13 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	if entry.Level != logrus.WarnLevel {
-		levelText = strings.ToUpper(entry.Level.String())
+		levelText = entry.Level.String()
 	} else {
-		levelText = "WARN"
+		levelText = "warn"
+	}
+
+	if !f.DisableUppercase {
+		levelText = strings.ToUpper(levelText)
 	}
 
 	level := levelColor(fmt.Sprintf("%5s", levelText))

--- a/formatter.go
+++ b/formatter.go
@@ -137,10 +137,14 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		messageFormat = fmt.Sprintf("%%-%ds", f.SpacePadding)
 	}
 
-	if f.ShortTimestamp {
-		fmt.Fprintf(b, "%s[%04d]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, miniTS(), reset, levelColor, levelText, reset, prefix, message)
+	if f.DisableTimestamp {
+		fmt.Fprintf(b, "%s%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, reset, levelColor, levelText, reset, prefix, message)
 	} else {
-		fmt.Fprintf(b, "%s[%s]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, entry.Time.Format(timestampFormat), reset, levelColor, levelText, reset, prefix, message)
+		if f.ShortTimestamp {
+			fmt.Fprintf(b, "%s[%04d]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, miniTS(), reset, levelColor, levelText, reset, prefix, message)
+		} else {
+			fmt.Fprintf(b, "%s[%s]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, entry.Time.Format(timestampFormat), reset, levelColor, levelText, reset, prefix, message)
+		}
 	}
 	for _, k := range keys {
 		v := entry.Data[k]

--- a/formatter.go
+++ b/formatter.go
@@ -156,6 +156,7 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	for k := range entry.Data {
 		keys = append(keys, k)
 	}
+	lastKeyIdx := len(keys) - 1
 
 	if !f.DisableSorting {
 		sort.Strings(keys)
@@ -194,11 +195,11 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat), true)
 		}
 		f.appendKeyValue(b, "level", entry.Level.String(), true)
-		for _, key := range keys {
-			f.appendKeyValue(b, key, entry.Data[key], true)
-		}
 		if entry.Message != "" {
-			f.appendKeyValue(b, "msg", entry.Message, false)
+			f.appendKeyValue(b, "msg", entry.Message, true)
+		}
+		for i, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key], i != lastKeyIdx)
 		}
 	}
 

--- a/formatter.go
+++ b/formatter.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mgutz/ansi"
 )
 
+const defaultTimestampFormat = time.RFC3339
+
 var (
 	baseTimestamp      time.Time    = time.Now()
 	defaultColorScheme *ColorScheme = &ColorScheme{
@@ -175,7 +177,7 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {
-		timestampFormat = logrus.DefaultTimestampFormat
+		timestampFormat = defaultTimestampFormat
 	}
 	if isFormatted {
 		isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors

--- a/formatter.go
+++ b/formatter.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/mgutz/ansi"
 )
 

--- a/formatter.go
+++ b/formatter.go
@@ -13,18 +13,45 @@ import (
 	"github.com/mgutz/ansi"
 )
 
-const reset = ansi.Reset
-
 var (
-	baseTimestamp time.Time
+	baseTimestamp time.Time = time.Now()
+	defaultColorScheme *ColorScheme = &ColorScheme{
+		InfoLevelStyle: "green",
+		WarnLevelStyle: "yellow",
+		ErrorLevelStyle: "red",
+		FatalLevelStyle: "red",
+		PanicLevelStyle: "red",
+		DebugLevelStyle: "blue",
+		PrefixStyle: "cyan",
+		TimestampStyle: "black+h",
+	}
+	defaultCompiledColorScheme *compiledColorScheme = compileColorScheme(defaultColorScheme)
 )
-
-func init() {
-	baseTimestamp = time.Now()
-}
 
 func miniTS() int {
 	return int(time.Since(baseTimestamp) / time.Second)
+}
+
+type ColorScheme struct {
+	InfoLevelStyle string
+	WarnLevelStyle string
+	ErrorLevelStyle string
+	FatalLevelStyle string
+	PanicLevelStyle string
+	DebugLevelStyle string
+	PrefixStyle string
+	TimestampStyle string
+}
+
+type compiledColorScheme struct {
+	InfoLevelColor func(string) string
+	WarnLevelColor func(string) string
+	ErrorLevelColor func(string) string
+	FatalLevelColor func(string) string
+	PanicLevelColor func(string) string
+	DebugLevelColor func(string) string
+	PrefixColor func(string) string
+	TimestampColor func(string) string
 }
 
 type TextFormatter struct {
@@ -38,8 +65,9 @@ type TextFormatter struct {
 	// system that already adds timestamps.
 	DisableTimestamp bool
 
-	// Enable logging of just the time passed since beginning of execution.
-	ShortTimestamp bool
+	// Enable logging the full timestamp when a TTY is attached instead of just
+	// the time passed since beginning of execution.
+	FullTimestamp bool
 
 	// Timestamp format to use for display when a full timestamp is printed.
 	TimestampFormat string
@@ -49,43 +77,88 @@ type TextFormatter struct {
 	// be desired.
 	DisableSorting bool
 
+	// Wrap empty fields in quotes if true.
+	QuoteEmptyFields bool
+
+	// Can be set to the override the default quoting character "
+	// with something else. For example: ', or `.
+	QuoteCharacter string
+
 	// Pad msg field with spaces on the right for display.
 	// The value for this parameter will be the size of padding.
 	// Its default value is zero, which means no padding will be applied for msg.
 	SpacePadding int
 
-	// Whether the logger's out is to a terminal
-	isTerminal   bool
-	terminalOnce sync.Once
+	// Color scheme to use.
+	colorScheme *compiledColorScheme
+
+	// Whether the logger's out is to a terminal.
+	isTerminal bool
+
+	sync.Once
+}
+
+func getCompiledColor(main string, fallback string) func (string) string {
+	var style string
+	if (main != "") {
+		style = main
+	} else {
+		style = fallback
+	}
+	return ansi.ColorFunc(style)
+}
+
+func compileColorScheme(s *ColorScheme) *compiledColorScheme {
+	return &compiledColorScheme{
+		InfoLevelColor: getCompiledColor(s.InfoLevelStyle, defaultColorScheme.InfoLevelStyle),
+		WarnLevelColor: getCompiledColor(s.WarnLevelStyle, defaultColorScheme.WarnLevelStyle),
+		ErrorLevelColor: getCompiledColor(s.ErrorLevelStyle, defaultColorScheme.ErrorLevelStyle),
+		FatalLevelColor: getCompiledColor(s.FatalLevelStyle, defaultColorScheme.FatalLevelStyle),
+		PanicLevelColor: getCompiledColor(s.PanicLevelStyle, defaultColorScheme.PanicLevelStyle),
+		DebugLevelColor: getCompiledColor(s.DebugLevelStyle, defaultColorScheme.DebugLevelStyle),
+		PrefixColor: getCompiledColor(s.PrefixStyle, defaultColorScheme.PrefixStyle),
+		TimestampColor: getCompiledColor(s.TimestampStyle, defaultColorScheme.TimestampStyle),
+	}
+}
+
+func (f *TextFormatter) init(entry *logrus.Entry) {
+	if len(f.QuoteCharacter) == 0 {
+		f.QuoteCharacter = "\""
+	}
+	if entry.Logger != nil {
+		f.isTerminal = logrus.IsTerminal(entry.Logger.Out)
+	}
+}
+
+func (f *TextFormatter) SetColorScheme(colorScheme *ColorScheme) {
+	f.colorScheme = compileColorScheme(colorScheme)
 }
 
 func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var b *bytes.Buffer
 	var keys []string = make([]string, 0, len(entry.Data))
 	for k := range entry.Data {
-		if k != "prefix" {
-			keys = append(keys, k)
-		}
+		keys = append(keys, k)
 	}
 
 	if !f.DisableSorting {
 		sort.Strings(keys)
 	}
-
-	b := &bytes.Buffer{}
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
 
 	prefixFieldClashes(entry.Data)
 
-	f.terminalOnce.Do(func() {
-		if entry.Logger != nil {
-			f.isTerminal = logrus.IsTerminal(entry.Logger.Out)
-		}
-	})
+	f.Do(func() { f.init(entry) })
 
 	isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {
-		timestampFormat = time.Stamp
+		timestampFormat = logrus.DefaultTimestampFormat
 	}
 	if isColored {
 		f.printColored(b, entry, keys, timestampFormat)
@@ -107,17 +180,27 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys []string, timestampFormat string) {
-	var levelColor string
+	var levelColor func(string) string
 	var levelText string
+	var colorScheme *compiledColorScheme
+	if (f.colorScheme == nil) {
+		colorScheme = defaultCompiledColorScheme
+	} else {
+		colorScheme = f.colorScheme
+	}
 	switch entry.Level {
 	case logrus.InfoLevel:
-		levelColor = ansi.Green
+		levelColor = colorScheme.InfoLevelColor
 	case logrus.WarnLevel:
-		levelColor = ansi.Yellow
-	case logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
-		levelColor = ansi.Red
+		levelColor = colorScheme.WarnLevelColor
+	case logrus.ErrorLevel:
+		levelColor = colorScheme.ErrorLevelColor
+	case logrus.FatalLevel:
+		levelColor = colorScheme.FatalLevelColor
+	case logrus.PanicLevel:
+		levelColor = colorScheme.PanicLevelColor
 	default:
-		levelColor = ansi.Blue
+		levelColor = colorScheme.DebugLevelColor
 	}
 
 	if entry.Level != logrus.WarnLevel {
@@ -126,15 +209,16 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		levelText = "WARN"
 	}
 
+	level := levelColor(fmt.Sprintf("%5s", levelText))
 	prefix := ""
 	message := entry.Message
 
 	if prefixValue, ok := entry.Data["prefix"]; ok {
-		prefix = fmt.Sprint(" ", ansi.Cyan, prefixValue, ":", reset)
+		prefix = colorScheme.PrefixColor(prefixValue.(string)+":")
 	} else {
 		prefixValue, trimmedMsg := extractPrefix(entry.Message)
 		if len(prefixValue) > 0 {
-			prefix = fmt.Sprint(" ", ansi.Cyan, prefixValue, ":", reset)
+			prefix = colorScheme.PrefixColor(prefixValue+":")
 			message = trimmedMsg
 		}
 	}
@@ -145,30 +229,37 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	if f.DisableTimestamp {
-		fmt.Fprintf(b, "%s%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, reset, levelColor, levelText, reset, prefix, message)
+		fmt.Fprintf(b, "%s %s "+messageFormat, level, prefix, message)
 	} else {
-		if f.ShortTimestamp {
-			fmt.Fprintf(b, "%s[%04d]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, miniTS(), reset, levelColor, levelText, reset, prefix, message)
+		var timestamp string
+		if !f.FullTimestamp {
+			timestamp = fmt.Sprintf("[%04d]", miniTS())
 		} else {
-			fmt.Fprintf(b, "%s[%s]%s %s%+5s%s%s "+messageFormat, ansi.LightBlack, entry.Time.Format(timestampFormat), reset, levelColor, levelText, reset, prefix, message)
+			timestamp = fmt.Sprintf("[%s]", entry.Time.Format(timestampFormat))
 		}
+		fmt.Fprintf(b, "%s %s %s "+messageFormat, colorScheme.TimestampColor(timestamp), level, prefix, message)
 	}
 	for _, k := range keys {
-		v := entry.Data[k]
-		fmt.Fprintf(b, " %s%s%s=%+v", levelColor, k, reset, v)
+		if (k != "prefix") {
+			v := entry.Data[k]
+			fmt.Fprintf(b, " %s=%+v", levelColor(k), v)
+		}
 	}
 }
 
-func needsQuoting(text string) bool {
+func (f *TextFormatter) needsQuoting(text string) bool {
+	if f.QuoteEmptyFields && len(text) == 0 {
+		return true
+	}
 	for _, ch := range text {
 		if !((ch >= 'a' && ch <= 'z') ||
 			(ch >= 'A' && ch <= 'Z') ||
 			(ch >= '0' && ch <= '9') ||
 			ch == '-' || ch == '.') {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func extractPrefix(msg string) (string, string) {
@@ -184,39 +275,49 @@ func extractPrefix(msg string) (string, string) {
 func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}) {
 	b.WriteString(key)
 	b.WriteByte('=')
+	f.appendValue(b, value)
+	b.WriteByte(' ')
+}
 
+func (f *TextFormatter) appendValue(b *bytes.Buffer, value interface{}) {
 	switch value := value.(type) {
 	case string:
-		if needsQuoting(value) {
+		if !f.needsQuoting(value) {
 			b.WriteString(value)
 		} else {
-			fmt.Fprintf(b, "%q", value)
+			fmt.Fprintf(b, "%s%v%s", f.QuoteCharacter, value, f.QuoteCharacter)
 		}
 	case error:
 		errmsg := value.Error()
-		if needsQuoting(errmsg) {
+		if !f.needsQuoting(errmsg) {
 			b.WriteString(errmsg)
 		} else {
-			fmt.Fprintf(b, "%q", value)
+			fmt.Fprintf(b, "%s%v%s", f.QuoteCharacter, errmsg, f.QuoteCharacter)
 		}
 	default:
 		fmt.Fprint(b, value)
 	}
-
-	b.WriteByte(' ')
 }
 
+// This is to not silently overwrite `time`, `msg` and `level` fields when
+// dumping it. If this code wasn't there doing:
+//
+//  logrus.WithField("level", 1).Info("hello")
+//
+// would just silently drop the user provided level. Instead with this code
+// it'll be logged as:
+//
+//  {"level": "info", "fields.level": 1, "msg": "hello", "time": "..."}
 func prefixFieldClashes(data logrus.Fields) {
-	_, ok := data["time"]
-	if ok {
-		data["fields.time"] = data["time"]
+	if t, ok := data["time"]; ok {
+		data["fields.time"] = t
 	}
-	_, ok = data["msg"]
-	if ok {
-		data["fields.msg"] = data["msg"]
+
+	if m, ok := data["msg"]; ok {
+		data["fields.msg"] = m
 	}
-	_, ok = data["level"]
-	if ok {
-		data["fields.level"] = data["level"]
+
+	if l, ok := data["level"]; ok {
+		data["fields.level"] = l
 	}
 }

--- a/formatter.go
+++ b/formatter.go
@@ -14,26 +14,26 @@ import (
 )
 
 var (
-	baseTimestamp time.Time = time.Now()
+	baseTimestamp      time.Time    = time.Now()
 	defaultColorScheme *ColorScheme = &ColorScheme{
-		InfoLevelStyle: "green",
-		WarnLevelStyle: "yellow",
+		InfoLevelStyle:  "green",
+		WarnLevelStyle:  "yellow",
 		ErrorLevelStyle: "red",
 		FatalLevelStyle: "red",
 		PanicLevelStyle: "red",
 		DebugLevelStyle: "blue",
-		PrefixStyle: "cyan",
-		TimestampStyle: "black+h",
+		PrefixStyle:     "cyan",
+		TimestampStyle:  "black+h",
 	}
 	noColorsColorScheme *compiledColorScheme = &compiledColorScheme{
-		InfoLevelColor: ansi.ColorFunc(""),
-		WarnLevelColor: ansi.ColorFunc(""),
+		InfoLevelColor:  ansi.ColorFunc(""),
+		WarnLevelColor:  ansi.ColorFunc(""),
 		ErrorLevelColor: ansi.ColorFunc(""),
 		FatalLevelColor: ansi.ColorFunc(""),
 		PanicLevelColor: ansi.ColorFunc(""),
 		DebugLevelColor: ansi.ColorFunc(""),
-		PrefixColor: ansi.ColorFunc(""),
-		TimestampColor: ansi.ColorFunc(""),
+		PrefixColor:     ansi.ColorFunc(""),
+		TimestampColor:  ansi.ColorFunc(""),
 	}
 	defaultCompiledColorScheme *compiledColorScheme = compileColorScheme(defaultColorScheme)
 )
@@ -43,25 +43,25 @@ func miniTS() int {
 }
 
 type ColorScheme struct {
-	InfoLevelStyle string
-	WarnLevelStyle string
+	InfoLevelStyle  string
+	WarnLevelStyle  string
 	ErrorLevelStyle string
 	FatalLevelStyle string
 	PanicLevelStyle string
 	DebugLevelStyle string
-	PrefixStyle string
-	TimestampStyle string
+	PrefixStyle     string
+	TimestampStyle  string
 }
 
 type compiledColorScheme struct {
-	InfoLevelColor func(string) string
-	WarnLevelColor func(string) string
+	InfoLevelColor  func(string) string
+	WarnLevelColor  func(string) string
 	ErrorLevelColor func(string) string
 	FatalLevelColor func(string) string
 	PanicLevelColor func(string) string
 	DebugLevelColor func(string) string
-	PrefixColor func(string) string
-	TimestampColor func(string) string
+	PrefixColor     func(string) string
+	TimestampColor  func(string) string
 }
 
 type TextFormatter struct {
@@ -111,9 +111,9 @@ type TextFormatter struct {
 	sync.Once
 }
 
-func getCompiledColor(main string, fallback string) func (string) string {
+func getCompiledColor(main string, fallback string) func(string) string {
 	var style string
-	if (main != "") {
+	if main != "" {
 		style = main
 	} else {
 		style = fallback
@@ -123,14 +123,14 @@ func getCompiledColor(main string, fallback string) func (string) string {
 
 func compileColorScheme(s *ColorScheme) *compiledColorScheme {
 	return &compiledColorScheme{
-		InfoLevelColor: getCompiledColor(s.InfoLevelStyle, defaultColorScheme.InfoLevelStyle),
-		WarnLevelColor: getCompiledColor(s.WarnLevelStyle, defaultColorScheme.WarnLevelStyle),
+		InfoLevelColor:  getCompiledColor(s.InfoLevelStyle, defaultColorScheme.InfoLevelStyle),
+		WarnLevelColor:  getCompiledColor(s.WarnLevelStyle, defaultColorScheme.WarnLevelStyle),
 		ErrorLevelColor: getCompiledColor(s.ErrorLevelStyle, defaultColorScheme.ErrorLevelStyle),
 		FatalLevelColor: getCompiledColor(s.FatalLevelStyle, defaultColorScheme.FatalLevelStyle),
 		PanicLevelColor: getCompiledColor(s.PanicLevelStyle, defaultColorScheme.PanicLevelStyle),
 		DebugLevelColor: getCompiledColor(s.DebugLevelStyle, defaultColorScheme.DebugLevelStyle),
-		PrefixColor: getCompiledColor(s.PrefixStyle, defaultColorScheme.PrefixStyle),
-		TimestampColor: getCompiledColor(s.TimestampStyle, defaultColorScheme.TimestampStyle),
+		PrefixColor:     getCompiledColor(s.PrefixStyle, defaultColorScheme.PrefixStyle),
+		TimestampColor:  getCompiledColor(s.TimestampStyle, defaultColorScheme.TimestampStyle),
 	}
 }
 
@@ -176,8 +176,8 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	if isFormatted {
 		isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
 		var colorScheme *compiledColorScheme
-		if (isColored) {
-			if (f.colorScheme == nil) {
+		if isColored {
+			if f.colorScheme == nil {
 				colorScheme = defaultCompiledColorScheme
 			} else {
 				colorScheme = f.colorScheme
@@ -232,11 +232,11 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	message := entry.Message
 
 	if prefixValue, ok := entry.Data["prefix"]; ok {
-		prefix = colorScheme.PrefixColor(prefixValue.(string)+":")
+		prefix = colorScheme.PrefixColor(prefixValue.(string) + ":")
 	} else {
 		prefixValue, trimmedMsg := extractPrefix(entry.Message)
 		if len(prefixValue) > 0 {
-			prefix = colorScheme.PrefixColor(prefixValue+":")
+			prefix = colorScheme.PrefixColor(prefixValue + ":")
 			message = trimmedMsg
 		}
 	}
@@ -258,7 +258,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		fmt.Fprintf(b, "%s %s %s "+messageFormat, colorScheme.TimestampColor(timestamp), level, prefix, message)
 	}
 	for _, k := range keys {
-		if (k != "prefix") {
+		if k != "prefix" {
 			v := entry.Data[k]
 			fmt.Fprintf(b, " %s=%+v", levelColor(k), v)
 		}

--- a/formatter.go
+++ b/formatter.go
@@ -196,10 +196,10 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		}
 		f.appendKeyValue(b, "level", entry.Level.String(), true)
 		if entry.Message != "" {
-			f.appendKeyValue(b, "msg", entry.Message, true)
+			f.appendKeyValue(b, "msg", entry.Message, lastKeyIdx >= 0)
 		}
 		for i, key := range keys {
-			f.appendKeyValue(b, key, entry.Data[key], i != lastKeyIdx)
+			f.appendKeyValue(b, key, entry.Data[key], lastKeyIdx != i)
 		}
 	}
 

--- a/formatter.go
+++ b/formatter.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -17,12 +17,10 @@ const reset = ansi.Reset
 
 var (
 	baseTimestamp time.Time
-	isTerminal    bool
 )
 
 func init() {
 	baseTimestamp = time.Now()
-	isTerminal = logrus.IsTerminal()
 }
 
 func miniTS() int {
@@ -55,6 +53,10 @@ type TextFormatter struct {
 	// The value for this parameter will be the size of padding.
 	// Its default value is zero, which means no padding will be applied for msg.
 	SpacePadding int
+
+	// Whether the logger's out is to a terminal
+	isTerminal   bool
+	terminalOnce sync.Once
 }
 
 func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -73,8 +75,13 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	prefixFieldClashes(entry.Data)
 
-	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
-	isColored := (f.ForceColors || isColorTerminal) && !f.DisableColors
+	f.terminalOnce.Do(func() {
+		if entry.Logger != nil {
+			f.isTerminal = logrus.IsTerminal(entry.Logger.Out)
+		}
+	})
+
+	isColored := (f.ForceColors || f.isTerminal) && !f.DisableColors
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,13 +1,43 @@
 package prefixed_test
 
 import (
+	. "github.com/x-cray/logrus-prefixed-formatter"
+
+	"github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
-func TestLogrusPrefixedFormatter(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "LogrusPrefixedFormatter Suite")
-}
+var _ = Describe("Formatter", func() {
+	var formatter *TextFormatter
+	var log *logrus.Logger
+	var output *LogOutput
+
+	BeforeEach(func() {
+		output = new(LogOutput)
+		formatter = new(TextFormatter)
+		log = logrus.New()
+		log.Out = output
+		log.Formatter = formatter
+		log.Level = logrus.DebugLevel
+	})
+
+	Describe("Formatting output", func() {
+		It("should output simple logfmt message", func() {
+			formatter.DisableTimestamp = true
+			log.Debug("test")
+			Ω(output.GetValue()).Should(Equal("level=debug msg=test\n"))
+		})
+
+		It("should output formatted message", func() {
+			formatter.DisableTimestamp = true
+			formatter.ForceFormatting = true
+			log.Debug("test")
+			Ω(output.GetValue()).Should(Equal("DEBUG test\n"))
+		})
+	})
+
+	Describe("Theming support", func() {
+
+	})
+})

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,13 @@
+package prefixed_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestLogrusPrefixedFormatter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LogrusPrefixedFormatter Suite")
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -3,7 +3,7 @@ package prefixed_test
 import (
 	. "github.com/x-cray/logrus-prefixed-formatter"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -22,13 +22,21 @@ var _ = Describe("Formatter", func() {
 		log.Level = logrus.DebugLevel
 	})
 
-	Describe("Formatting output", func() {
-		It("should output simple logfmt message", func() {
+	Describe("logfmt output", func() {
+		It("should output simple message", func() {
 			formatter.DisableTimestamp = true
 			log.Debug("test")
 			Ω(output.GetValue()).Should(Equal("level=debug msg=test\n"))
 		})
 
+		It("should output message with additional field", func() {
+			formatter.DisableTimestamp = true
+			log.WithFields(logrus.Fields{ "animal": "walrus" }).Debug("test")
+			Ω(output.GetValue()).Should(Equal("level=debug msg=test animal=walrus\n"))
+		})
+	})
+
+	Describe("Formatted output", func() {
 		It("should output formatted message", func() {
 			formatter.DisableTimestamp = true
 			formatter.ForceFormatting = true

--- a/logrus_prefixed_formatter_suite_test.go
+++ b/logrus_prefixed_formatter_suite_test.go
@@ -1,0 +1,26 @@
+package prefixed_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+type LogOutput struct {
+	buffer string
+}
+
+func (o *LogOutput) Write(p []byte) (int, error) {
+	o.buffer += string(p[:])
+	return len(p), nil
+}
+
+func (o *LogOutput) GetValue() string {
+	return o.buffer
+}
+
+func TestLogrusPrefixedFormatter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LogrusPrefixedFormatter Suite")
+}


### PR DESCRIPTION
Synchronized TykTechnologies/logrus-prefixed-formatter with his parent repo x-cray/logrus-prefixed-formatter in order that we can use the latest features as force colors. This PR should be merged in parallel with this PR: https://github.com/TykTechnologies/logrus/pull/1   as it depends directly on the version of logrus.
